### PR TITLE
Add Keycloak authentication flow with boot loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.1.13"
+    "tailwindcss": "^4.1.13",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.13
         version: 4.1.13
+      zustand:
+        specifier: ^5.0.8
+        version: 5.0.8(@types/react@19.1.14)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
     devDependencies:
       '@biomejs/biome':
         specifier: 2.2.4
@@ -1724,6 +1727,24 @@ packages:
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
+  zustand@5.0.8:
+    resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@asamuzakjp/css-color@4.0.5':
@@ -3227,3 +3248,9 @@ snapshots:
   yallist@5.0.0: {}
 
   zod@4.1.11: {}
+
+  zustand@5.0.8(@types/react@19.1.14)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1)):
+    optionalDependencies:
+      '@types/react': 19.1.14
+      react: 19.1.1
+      use-sync-external-store: 1.5.0(react@19.1.1)

--- a/src/components/app-wrapper.tsx
+++ b/src/components/app-wrapper.tsx
@@ -1,0 +1,67 @@
+import { Outlet, useLocation, useNavigate } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { useAuthStore } from "../stores/auth-store";
+import { BootLoader } from "./boot-loader";
+import { RootLayout } from "./root-layout";
+
+const BOOT_TIME_MS = 3000;
+const REDIRECT_TIME_MS = 2000;
+
+export function AppWrapper() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { isAuthenticated, isBooting, completeBoot } = useAuthStore();
+  const [bootPhase, setBootPhase] = useState<
+    "booting" | "redirecting" | "complete"
+  >("booting");
+
+  useEffect(() => {
+    const bootSequence = async () => {
+      // Don't show boot loader for keycloak and logout pages
+      const isAuthRoute =
+        location.pathname === "/keycloak" || location.pathname === "/logout";
+
+      if (isAuthRoute) {
+        completeBoot();
+        setBootPhase("complete");
+        return;
+      }
+
+      if (isBooting) {
+        setBootPhase("booting");
+
+        // Initial boot time
+        await new Promise((resolve) => setTimeout(resolve, BOOT_TIME_MS));
+
+        if (isAuthenticated) {
+          completeBoot();
+          setBootPhase("complete");
+        } else {
+          setBootPhase("redirecting");
+          await new Promise((resolve) => setTimeout(resolve, REDIRECT_TIME_MS));
+          completeBoot();
+          navigate({ to: "/keycloak" });
+        }
+      } else {
+        setBootPhase("complete");
+      }
+    };
+
+    bootSequence();
+  }, [isAuthenticated, isBooting, completeBoot, navigate, location.pathname]);
+
+  // Show boot loader only for protected routes during boot
+  const isAuthRoute =
+    location.pathname === "/keycloak" || location.pathname === "/logout";
+
+  if (!isAuthRoute && (isBooting || bootPhase !== "complete")) {
+    return <BootLoader />;
+  }
+
+  // For auth routes, render directly without the main layout
+  if (isAuthRoute) {
+    return <Outlet />;
+  }
+
+  return <RootLayout />;
+}

--- a/src/components/boot-loader.tsx
+++ b/src/components/boot-loader.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+const MAX_DOTS = 3;
+const DOTS_ANIMATION_INTERVAL_MS = 500;
+
+export function BootLoader() {
+  const [dots, setDots] = useState(1);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDots((prev) => (prev === MAX_DOTS ? 1 : prev + 1));
+    }, DOTS_ANIMATION_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">
+      <div className="text-center">
+        <div className="mb-8">
+          <div className="mb-6 flex justify-center">
+            <div className="flex space-x-2">
+              <div
+                className="h-3 w-3 animate-bounce rounded-full bg-blue-600"
+                style={{ animationDelay: "0ms" }}
+              />
+              <div
+                className="h-3 w-3 animate-bounce rounded-full bg-blue-600"
+                style={{ animationDelay: "150ms" }}
+              />
+              <div
+                className="h-3 w-3 animate-bounce rounded-full bg-blue-600"
+                style={{ animationDelay: "300ms" }}
+              />
+            </div>
+          </div>
+          <h1 className="mb-2 font-bold text-2xl text-gray-800">
+            Booting up application
+          </h1>
+          <p className="text-gray-600">Routing to Keycloak{".".repeat(dots)}</p>
+        </div>
+        <div className="mx-auto h-1 w-48 overflow-hidden rounded-full bg-gray-200">
+          <div className="h-full animate-pulse bg-gradient-to-r from-blue-400 to-blue-600" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/keycloak-login.tsx
+++ b/src/components/keycloak-login.tsx
@@ -1,0 +1,77 @@
+import { useNavigate } from "@tanstack/react-router";
+import { Shield } from "lucide-react";
+import { useState } from "react";
+import { useAuthStore } from "../stores/auth-store";
+import { Button } from "./ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "./ui/card";
+
+const KEYCLOAK_AUTH_DELAY_MS = 1500;
+
+export function KeycloakLogin() {
+  const [isLoading, setIsLoading] = useState(false);
+  const login = useAuthStore((state) => state.login);
+  const navigate = useNavigate();
+
+  const handleLogin = async () => {
+    setIsLoading(true);
+
+    // Simulate Keycloak authentication delay
+    await new Promise((resolve) => setTimeout(resolve, KEYCLOAK_AUTH_DELAY_MS));
+
+    // Mark user as authenticated
+    login();
+
+    // Navigate to home page
+    navigate({ to: "/" });
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">
+      <Card className="w-full max-w-md shadow-xl">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-blue-100">
+            <Shield className="h-8 w-8 text-blue-600" />
+          </div>
+          <CardTitle className="text-2xl">Keycloak Authentication</CardTitle>
+          <CardDescription>
+            Sign in to access the Company Analysis Platform
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
+            <p className="text-center text-blue-700 text-sm">
+              This is a demo authentication flow. Click the button below to
+              simulate a Keycloak login.
+            </p>
+          </div>
+
+          <Button
+            className="w-full"
+            disabled={isLoading}
+            onClick={handleLogin}
+            size="lg"
+          >
+            {isLoading ? (
+              <>
+                <span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent border-b-transparent" />
+                Authenticating...
+              </>
+            ) : (
+              "Login with Keycloak"
+            )}
+          </Button>
+
+          <p className="text-center text-gray-500 text-xs">
+            Demo Mode • No credentials required
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/logout-page.tsx
+++ b/src/components/logout-page.tsx
@@ -1,0 +1,53 @@
+import { useNavigate } from "@tanstack/react-router";
+import { LogOut } from "lucide-react";
+import { useEffect } from "react";
+import { useAuthStore } from "../stores/auth-store";
+import { Button } from "./ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "./ui/card";
+
+export function LogoutPage() {
+  const logout = useAuthStore((state) => state.logout);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Clear the auth state when component mounts
+    logout();
+  }, [logout]);
+
+  const handleReturnHome = () => {
+    navigate({ to: "/" });
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-gradient-to-br from-gray-50 to-slate-100">
+      <Card className="w-full max-w-md shadow-xl">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gray-100">
+            <LogOut className="h-8 w-8 text-gray-600" />
+          </div>
+          <CardTitle className="text-2xl">You've been logged out</CardTitle>
+          <CardDescription>
+            Your session has been terminated successfully
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+            <p className="text-center text-gray-600 text-sm">
+              You will need to authenticate again to access the platform.
+            </p>
+          </div>
+
+          <Button className="w-full" onClick={handleReturnHome} size="lg">
+            Go to Login
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/root-layout.tsx
+++ b/src/components/root-layout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
-import { Building2 } from "lucide-react";
+import { Building2, LogOut } from "lucide-react";
 import { Button } from "./ui/button";
 
 export function RootLayout() {
@@ -31,6 +31,10 @@ export function RootLayout() {
     navigate({ to: "/" });
   };
 
+  const handleLogout = () => {
+    navigate({ to: "/logout" });
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Top Navigation Bar */}
@@ -44,26 +48,37 @@ export function RootLayout() {
               </h1>
             </div>
 
-            {companyId && departmentId && (
-              <div className="flex items-center space-x-4">
-                <span className="text-gray-600 text-sm">
-                  <span className="font-medium">
-                    {companyNames[companyId] || companyId}
+            <div className="flex items-center space-x-4">
+              {companyId && departmentId && (
+                <>
+                  <span className="text-gray-600 text-sm">
+                    <span className="font-medium">
+                      {companyNames[companyId] || companyId}
+                    </span>
+                    <span className="mx-2">•</span>
+                    <span className="font-medium">
+                      {departmentNames[departmentId] || departmentId}
+                    </span>
                   </span>
-                  <span className="mx-2">•</span>
-                  <span className="font-medium">
-                    {departmentNames[departmentId] || departmentId}
-                  </span>
-                </span>
-                <Button
-                  onClick={handleCompanyDepartmentChange}
-                  size="sm"
-                  variant="outline"
-                >
-                  Change Company/Department
-                </Button>
-              </div>
-            )}
+                  <Button
+                    onClick={handleCompanyDepartmentChange}
+                    size="sm"
+                    variant="outline"
+                  >
+                    Change Company/Department
+                  </Button>
+                </>
+              )}
+              <Button
+                className="gap-2"
+                onClick={handleLogout}
+                size="sm"
+                variant="ghost"
+              >
+                <LogOut className="h-4 w-4" />
+                Logout
+              </Button>
+            </div>
           </div>
         </div>
       </header>

--- a/src/stores/auth-store.ts
+++ b/src/stores/auth-store.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type AuthStore = {
+  isAuthenticated: boolean;
+  isBooting: boolean;
+  login: () => void;
+  logout: () => void;
+  startBoot: () => void;
+  completeBoot: () => void;
+};
+
+export const useAuthStore = create<AuthStore>()(
+  persist(
+    (set) => ({
+      isAuthenticated: false,
+      isBooting: true,
+      login: () => set({ isAuthenticated: true }),
+      logout: () => set({ isAuthenticated: false, isBooting: true }),
+      startBoot: () => set({ isBooting: true }),
+      completeBoot: () => set({ isBooting: false }),
+    }),
+    {
+      name: "auth-storage",
+      partialize: (state) => ({ isAuthenticated: state.isAuthenticated }),
+    }
+  )
+);


### PR DESCRIPTION
## Summary
- Implemented demo authentication system with Keycloak-style login flow
- Added boot loading screen with animated UI showing "Booting up application"
- Created artificial authentication that persists until explicit logout

## Features
### Boot Loading Screen
- 5-second boot sequence (3s boot + 2s redirect)
- Animated bouncing dots and "Routing to Keycloak" message
- Shows on initial app load and after logout

### Authentication Routes
- `/keycloak` - Demo login page with artificial authentication
- `/logout` - Logout confirmation page that clears session
- All main routes protected with auth checks

### State Management
- Zustand store with persistence for auth state
- Session remembered across page refreshes
- Auth state cleared only on explicit logout

### UI Updates
- Added logout button to top navigation bar
- Logout button always visible for easy access

## Test Plan
- [ ] Navigate to app root - should see boot loading animation
- [ ] After boot, should redirect to /keycloak login page
- [ ] Click login button - should authenticate and redirect to home
- [ ] Refresh page - should remain authenticated
- [ ] Click logout button - should go to logout page
- [ ] Click "Go to Login" - should restart boot sequence
- [ ] Try accessing protected routes when logged out - should redirect to /keycloak