### PR TITLE
Adjust boot loader flow for unauthenticated frontpage

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -37,12 +37,6 @@ export const rootRoute = createRootRoute({
 const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/",
-  beforeLoad: () => {
-    const { isAuthenticated } = useAuthStore.getState();
-    if (!isAuthenticated) {
-      throw redirect({ to: "/keycloak" });
-    }
-  },
   component: CompanyDepartmentSelection,
 });
 

--- a/src/components/app-wrapper.tsx
+++ b/src/components/app-wrapper.tsx
@@ -1,66 +1,39 @@
 import { Outlet, useLocation, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useAuthStore } from "../stores/auth-store";
 import { BootLoader } from "./boot-loader";
 import { RootLayout } from "./root-layout";
 
-const BOOT_TIME_MS = 3000;
-const REDIRECT_TIME_MS = 2000;
+const BOOT_REDIRECT_DELAY_MS = 5000;
 
 export function AppWrapper() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { isAuthenticated, isBooting, completeBoot } = useAuthStore();
-  const [bootPhase, setBootPhase] = useState<
-    "booting" | "redirecting" | "complete"
-  >("booting");
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
-  useEffect(() => {
-    const bootSequence = async () => {
-      // Don't show boot loader for keycloak and logout pages
-      const isAuthRoute =
-        location.pathname === "/keycloak" || location.pathname === "/logout";
-
-      if (isAuthRoute) {
-        completeBoot();
-        setBootPhase("complete");
-        return;
-      }
-
-      if (isBooting) {
-        setBootPhase("booting");
-
-        // Initial boot time
-        await new Promise((resolve) => setTimeout(resolve, BOOT_TIME_MS));
-
-        if (isAuthenticated) {
-          completeBoot();
-          setBootPhase("complete");
-        } else {
-          setBootPhase("redirecting");
-          await new Promise((resolve) => setTimeout(resolve, REDIRECT_TIME_MS));
-          completeBoot();
-          navigate({ to: "/keycloak" });
-        }
-      } else {
-        setBootPhase("complete");
-      }
-    };
-
-    bootSequence();
-  }, [isAuthenticated, isBooting, completeBoot, navigate, location.pathname]);
-
-  // Show boot loader only for protected routes during boot
   const isAuthRoute =
     location.pathname === "/keycloak" || location.pathname === "/logout";
+  const isFrontPage = location.pathname === "/";
+  const shouldShowBoot = !isAuthRoute && isFrontPage && !isAuthenticated;
 
-  if (!isAuthRoute && (isBooting || bootPhase !== "complete")) {
-    return <BootLoader />;
-  }
+  useEffect(() => {
+    if (!shouldShowBoot) {
+      return;
+    }
 
-  // For auth routes, render directly without the main layout
+    const redirectTimer = setTimeout(() => {
+      navigate({ to: "/keycloak", replace: true });
+    }, BOOT_REDIRECT_DELAY_MS);
+
+    return () => clearTimeout(redirectTimer);
+  }, [shouldShowBoot, navigate]);
+
   if (isAuthRoute) {
     return <Outlet />;
+  }
+
+  if (shouldShowBoot) {
+    return <BootLoader />;
   }
 
   return <RootLayout />;

--- a/src/stores/auth-store.ts
+++ b/src/stores/auth-store.ts
@@ -3,22 +3,16 @@ import { persist } from "zustand/middleware";
 
 type AuthStore = {
   isAuthenticated: boolean;
-  isBooting: boolean;
   login: () => void;
   logout: () => void;
-  startBoot: () => void;
-  completeBoot: () => void;
 };
 
 export const useAuthStore = create<AuthStore>()(
   persist(
     (set) => ({
       isAuthenticated: false,
-      isBooting: true,
       login: () => set({ isAuthenticated: true }),
-      logout: () => set({ isAuthenticated: false, isBooting: true }),
-      startBoot: () => set({ isBooting: true }),
-      completeBoot: () => set({ isBooting: false }),
+      logout: () => set({ isAuthenticated: false }),
     }),
     {
       name: "auth-storage",


### PR DESCRIPTION
## Summary
- show the boot loader on the frontpage for unauthenticated sessions before redirecting to Keycloak
- simplify the auth store to drop unused boot state while keeping persistence
- allow the frontpage route to render without an auth guard while other routes stay protected

## Testing
- pnpm test (fails: No test files found)